### PR TITLE
feat: add Linux/Fedora terminal support with Wayland detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+**Linux** (Fedora/RPM):
+```bash
+sudo dnf install -y \
+  webkit2gtk4.1-devel \
+  openssl-devel \
+  gtk3-devel \
+  libayatana-appindicator-gtk3-devel \
+  librsvg2-devel \
+  curl wget file gcc make
+
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+
+# Enable cron scheduling support
+sudo dnf install -y cronie
+sudo systemctl enable --now crond
+```
+
+> **Fedora note:** If `libayatana-appindicator-gtk3-devel` is not found, try `libappindicator-gtk3-devel`. If `webkit2gtk4.1-devel` is missing, also install `libsoup3-devel`.
+
+> **Wayland:** ATM supports Wayland natively via gnome-terminal or konsole. If you are running a pure Wayland session (no XWayland), ensure one of these is installed.
+
 </details>
 
 **Build for production**:
@@ -221,7 +244,8 @@ pnpm tauri build
 |----------|--------|---------|
 | Windows | Full support | PowerShell |
 | macOS | Full support | bash (Terminal.app) |
-| Linux | Supported | bash |
+| Linux (Debian/Ubuntu) | Supported | gnome-terminal, xterm, or any installed emulator |
+| Linux (Fedora/RPM) | Supported | konsole, gnome-terminal, alacritty, kitty, xterm |
 
 ---
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -254,6 +254,42 @@ fn delete_scheduled_task(task_name: String) -> Result<String, String> {
     }
 }
 
+/// Finds an available terminal emulator, preferring Wayland-native ones when running
+/// under a pure Wayland session (WAYLAND_DISPLAY set, DISPLAY unset).
+#[cfg(target_os = "linux")]
+fn find_terminal_emulator() -> Option<&'static str> {
+    let wayland = std::env::var("WAYLAND_DISPLAY").is_ok();
+    let x11 = std::env::var("DISPLAY").is_ok();
+    let pure_wayland = wayland && !x11;
+
+    // X11-only terminals that won't work without XWayland
+    const X11_ONLY: &[&str] = &["xterm", "urxvt"];
+
+    // Ordered by preference: Debian compat first, then common DEs, then fallbacks
+    const CANDIDATES: &[&str] = &[
+        "x-terminal-emulator", // Debian/Ubuntu alternatives system
+        "gnome-terminal",      // GNOME (native Wayland)
+        "konsole",             // KDE (native Wayland, default on Fedora KDE)
+        "xfce4-terminal",      // XFCE
+        "alacritty",           // Modern, widespread
+        "kitty",               // Modern, widespread
+        "tilix",               // GNOME alternative
+        "xterm",               // X11 fallback
+        "urxvt",               // X11 fallback
+    ];
+
+    CANDIDATES.iter().find(|&&term| {
+        if pure_wayland && X11_ONLY.contains(&term) {
+            return false;
+        }
+        StdCommand::new("which")
+            .arg(term)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }).copied()
+}
+
 /// Opens a visible terminal window running the given script.
 #[tauri::command]
 fn open_terminal(script_path: String) -> Result<(), String> {
@@ -287,21 +323,22 @@ fn open_terminal(script_path: String) -> Result<(), String> {
 
     #[cfg(target_os = "linux")]
     {
-        let terminals = [
-            ("x-terminal-emulator", vec!["-e", &script_path]),
-            ("gnome-terminal", vec!["--", &script_path]),
-            ("xterm", vec!["-e", &script_path]),
-        ];
-        let mut launched = false;
-        for (term, args) in &terminals {
-            if StdCommand::new(term).args(args).spawn().is_ok() {
-                launched = true;
-                break;
-            }
-        }
-        if !launched {
-            return Err("No terminal emulator found".into());
-        }
+        let term = find_terminal_emulator().ok_or_else(|| {
+            "No terminal emulator found. Install gnome-terminal, konsole, xterm, or another terminal emulator.".to_string()
+        })?;
+
+        // Terminals that use "--" as argument separator instead of "-e"
+        const DASH_DASH_TERMS: &[&str] = &["gnome-terminal", "konsole", "kitty"];
+        let args: Vec<&str> = if DASH_DASH_TERMS.contains(&term) {
+            vec!["--", &script_path]
+        } else {
+            vec!["-e", &script_path]
+        };
+
+        StdCommand::new(term)
+            .args(&args)
+            .spawn()
+            .map_err(|e| format!("Failed to open terminal '{}': {}", term, e))?;
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

On Fedora (and other RPM-based distributions), launching a terminal from ATM fails silently. The previous code only tried `x-terminal-emulator`, `gnome-terminal`, and `xterm` — in that order. `x-terminal-emulator` is a Debian/Ubuntu alternatives-system mechanism that does not exist on Fedora, and `xterm` is not installed by default.

This means the "Deploy Team" button does nothing on Fedora out of the box.

## Solution

### `src-tauri/src/lib.rs`

- Extracted a new `find_terminal_emulator()` helper (Linux-only, `#[cfg(target_os = "linux")]`) that probes installed terminals in order of preference:
  `x-terminal-emulator` → `gnome-terminal` → `konsole` → `xfce4-terminal` → `alacritty` → `kitty` → `tilix` → `xterm` → `urxvt`
- Added **Wayland detection**: if `WAYLAND_DISPLAY` is set and `DISPLAY` is not (pure Wayland, no XWayland), X11-only terminals (`xterm`, `urxvt`) are skipped automatically
- Correct argument separator per terminal: `--` for `gnome-terminal`, `konsole`, `kitty`; `-e` for everything else
- Clear error message if no terminal is found, listing recommended options

### `README.md`

- Added a **Fedora/DNF** prerequisites block with all required `dnf install` commands
- Added `cronie` setup instructions (needed for cron scheduling)
- Added a Wayland compatibility note
- Updated the platform compatibility table to distinguish Debian/Ubuntu from Fedora/RPM

## Testing

Tested on **Fedora 43, GNOME, Wayland + XWayland**:
- `pnpm tauri dev` — app launches, terminal spawning works via `gnome-terminal`
- `pnpm tauri build` — produces `.rpm` (7.9 MB) and `.deb` successfully

## Notes

- No changes to Windows or macOS code paths
- No new dependencies added
- The `x-terminal-emulator` entry is kept first so Debian/Ubuntu behavior is unchanged